### PR TITLE
add function for extract appid and name

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -1,18 +1,9 @@
 package main
 
 import (
-	"github.com/Tomas-vilte/GCPSteamAnalytics/db"
-	"github.com/Tomas-vilte/GCPSteamAnalytics/handlers"
-	"log"
+	"fmt"
 )
 
 func main() {
-
-	fetcher := &handlers.RealDataFetcher{}
-	database := &db.MySQLDatabase{}
-
-	err := db.InsertData(fetcher, database)
-	if err != nil {
-		log.Fatalf("Error al cargar los datos en la base de datos: %v", err)
-	}
+	fmt.Println("hola")
 }


### PR DESCRIPTION
Title: Add GetAppIDsAndNames function to the Database interface

Description:
This Pull Request adds a new function called `GetAppIDsAndNames` to the Database interface. The function is intended to retrieve the appids and names from the database, which will be later used to fetch detailed information about the games from the Steam API and store it in the database.

Changes Made:
- Added the `GetAppIDs` function to the `Database` interface.
- Implemented the `GetAppIDs` function in the `MySQLDatabase` struct.

Reason for the Change:
By adding the `GetAppIDsAndNames` function to the `Database` interface, we provide a clear way for the SteamData component to access the necessary appids and names from the database. This abstraction allows the SteamData component to focus on fetching detailed game information from the Steam API without having to directly interact with the database.