### PR TITLE
add method LoadLastProcessedAppid

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -28,6 +28,6 @@ func main() {
 
 	steamAPI := &steamapi.SteamAPI{DB: db}
 
-	gameDetails := steamAPI.ExtractAndSaveLimitedGameDetails(5000)
+	gameDetails := steamAPI.ExtractAndSaveLimitedGameDetails(10)
 	fmt.Println(gameDetails)
 }

--- a/steamapi/getGameDetailsFromAPI.go
+++ b/steamapi/getGameDetailsFromAPI.go
@@ -25,9 +25,14 @@ func backoffDuration(attempt int) time.Duration {
 const maxAttempts = 10 // Número máximo de intentos de solicitud
 
 func (s *SteamAPI) ExtractAndSaveLimitedGameDetails(limit int) error {
+	// Cargar el último appid procesado desde la base de datos
+	lastProcessedAppID, err := s.LoadLastProcessedAppid()
+	if err != nil {
+		return err
+	}
 
 	// Obtener los appids desde la base de datos
-	appids, err := s.GetAppIDs()
+	appids, err := s.GetAppIDs(lastProcessedAppID)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Added function LoadLastProcessedAppid

This pull request adds a function: LoadLastProcessedAppid. This function allows to store the last processed appid

LoadLastProcessedAppid reads the last processed appid from the state_table and returns its value.