### PR TITLE
add method SaveLastProcessedAppid

### DIFF
--- a/steamapi/implement.go
+++ b/steamapi/implement.go
@@ -118,7 +118,7 @@ func (s *SteamAPI) GameExistsInDatabase(appid int) (bool, error) {
 	return count > 0, nil
 }
 
-// Función para cargar el último appid procesado desde la tabla state_table
+// LoadLastProcessedAppid Función para cargar el último appid procesado desde la tabla state_table
 func (s *SteamAPI) LoadLastProcessedAppid() (int, error) {
 	var lastProcessedAppid int
 	query := "SELECT last_appid FROM state_table"
@@ -127,4 +127,14 @@ func (s *SteamAPI) LoadLastProcessedAppid() (int, error) {
 		return 0, err
 	}
 	return lastProcessedAppid, nil
+}
+
+// SaveLastProcessedAppid Función para guardar el último appid procesado en la tabla state_table
+func (s *SteamAPI) SaveLastProcessedAppid(lastProcessedAppid int) error {
+	query := "UPDATE state_table SET last_appid = ?"
+	_, err := s.DB.Exec(query, lastProcessedAppid)
+	if err != nil {
+		return err
+	}
+	return nil
 }

--- a/steamapi/models/models.go
+++ b/steamapi/models/models.go
@@ -17,6 +17,8 @@ type SteamApiResponse struct {
 type SteamData interface {
 	ExtractAndSaveLimitedGameDetails(limit int) error
 	InsertInBatch(items []GameDetails) error
-	GetAppIDs() ([]int, error)
+	GetAppIDs(appid int) ([]int, error)
 	GameExistsInDatabase(appid int) (bool, error)
+	SaveLastProcessedAppid(lastProcessedAppid int) error
+	LoadLastProcessedAppid() (int, error)
 }


### PR DESCRIPTION
Added LoadLastProcessedAppid and SaveLastProcessedAppid functions

This pull request adds two new functions: LoadLastProcessedAppid and SaveLastProcessedAppid. These functions allow the last processed appid to be stored and retrieved in a state table, allowing the application to resume processing from where it left off in the event of a crash or stoppage.

LoadLastProcessedAppid reads the last processed appid from the state table and returns its value. SaveLastProcessedAppid updates the value of the last processed appid in the state table.

These functions are useful for maintaining the state of the data collection process and continuing from where it left off in case of interruptions. This improves the efficiency and reliability of the data collection process.